### PR TITLE
Allow an optional precision value

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -8,6 +8,12 @@ const example = [
   [-126.453, 43.252],
 ];
 
+const example_with_precision = [
+  [-12.02, 3.85],
+  [-12.095, 4.07],
+  [-12.6453, 4.3252],
+];
+
 const exampleWithZ = [
   [-120.2, 38.5, 0],
   [-120.95, 40.7, 0],
@@ -37,6 +43,11 @@ const geojson: LineString = {
   coordinates: example,
 };
 
+const geojson_with_precision: LineString = {
+  type: "LineString",
+  coordinates: example_with_precision,
+};
+
 describe("#decode()", () => {
   it("decodes an empty Array", () => {
     expect(polyline.decode("")).toEqual([]);
@@ -49,8 +60,19 @@ describe("#decode()", () => {
     ]);
   });
 
+  it("decodes any string, but coordinates will be weird with custom precision", () => {
+    expect(polyline.decode("Hello, world!", 6)).toEqual([
+      [7.084755, -0.000005],
+      [43.483615, -0.000006],
+    ]);
+  });
+
   it("decodes a String into an Array of lat/lon pairs", () => {
     expect(polyline.decode("_p~iF~ps|U_ulLnnqC_mqNvxq`@")).toEqual(example);
+  });
+
+  it("decodes a String into an Array of lat/lon pairs with custom precision", () => {
+    expect(polyline.decode("_p~iF~ps|U_ulLnnqC_mqNvxq`@", 6)).toEqual(example_with_precision);
   });
 });
 
@@ -77,9 +99,19 @@ describe("#encode()", () => {
     expect(polyline.encode(example)).toEqual("_p~iF~ps|U_ulLnnqC_mqNvxq`@");
   });
 
+  it("encodes an Array of lat/lon pairs into a String with custom precision", () => {
+    expect(polyline.encode(example, 6)).toEqual("_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI");
+  });
+
   it("encodes an Array of lat/lon/z into the same string as lat/lon", () => {
     expect(polyline.encode(exampleWithZ)).toEqual(
       "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+    );
+  });
+
+  it("encodes an Array of lat/lon/z into the same string as lat/lon with custom precision", () => {
+    expect(polyline.encode(exampleWithZ, 6)).toEqual(
+      "_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI"
     );
   });
 
@@ -87,9 +119,19 @@ describe("#encode()", () => {
     expect(polyline.encode(example_rounding)).toEqual("?A?@");
   });
 
+  it("encodes with proper rounding with custom precision", () => {
+    expect(polyline.encode(example_rounding, 6)).toEqual("?K?F");
+  });
+
   it("encodes with proper negative rounding", () => {
     expect(polyline.encode(example_rounding_negative)).toEqual(
       "ss`{E~kbkTeAQw@J"
+    );
+  });
+
+  it("encodes with proper negative rounding with custom precision", () => {
+    expect(polyline.encode(example_rounding_negative, 6)).toEqual(
+      "gmowcAfaaxtEaUsD_PdB"
     );
   });
 });
@@ -100,12 +142,24 @@ describe("#fromGeoJSON()", () => {
       "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
     );
   });
+
+  it("allows geojson geometries with custom precision", () => {
+    expect(polyline.geoJSONToPolyline(geojson, 6)).toEqual(
+      "_izlhA~rlgdF_{geC~ywl@_kwzCn`{nI"
+    );
+  });
 });
 
 describe("#toGeoJSON()", () => {
   it("flips coordinates and decodes geometry", () => {
     expect(polyline.polylineToGeoJSON("_p~iF~ps|U_ulLnnqC_mqNvxq`@")).toEqual(
       geojson
+    );
+  });
+
+  it("flips coordinates and decodes geometry with custom precision", () => {
+    expect(polyline.polylineToGeoJSON("_p~iF~ps|U_ulLnnqC_mqNvxq`@", 6)).toEqual(
+      geojson_with_precision
     );
   });
 });

--- a/docs/assets/highlight.css
+++ b/docs/assets/highlight.css
@@ -1,22 +1,36 @@
 :root {
+    --light-hl-0: #000000;
+    --dark-hl-0: #D4D4D4;
+    --light-hl-1: #001080;
+    --dark-hl-1: #9CDCFE;
     --light-code-background: #FFFFFF;
     --dark-code-background: #1E1E1E;
 }
 
 @media (prefers-color-scheme: light) { :root {
+    --hl-0: var(--light-hl-0);
+    --hl-1: var(--light-hl-1);
     --code-background: var(--light-code-background);
 } }
 
 @media (prefers-color-scheme: dark) { :root {
+    --hl-0: var(--dark-hl-0);
+    --hl-1: var(--dark-hl-1);
     --code-background: var(--dark-code-background);
 } }
 
 :root[data-theme='light'] {
+    --hl-0: var(--light-hl-0);
+    --hl-1: var(--light-hl-1);
     --code-background: var(--light-code-background);
 }
 
 :root[data-theme='dark'] {
+    --hl-0: var(--dark-hl-0);
+    --hl-1: var(--dark-hl-1);
     --code-background: var(--dark-code-background);
 }
 
+.hl-0 { color: var(--hl-0); }
+.hl-1 { color: var(--hl-1); }
 pre, code { background: var(--code-background); }

--- a/docs/functions/decode.html
+++ b/docs/functions/decode.html
@@ -15,7 +15,7 @@
 <h1>Function decode</h1></div>
 <section class="tsd-panel">
 <ul class="tsd-signatures tsd-kind-function">
-<li class="tsd-signature tsd-anchor-link" id="decode">decode<span class="tsd-signature-symbol">(</span>str<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Position</span><span class="tsd-signature-symbol">[]</span><a href="#decode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></li>
+<li class="tsd-signature tsd-anchor-link" id="decode">decode<span class="tsd-signature-symbol">(</span>str<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, precision<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Position</span><span class="tsd-signature-symbol">[]</span><a href="#decode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Decodes any string into a [longitude, latitude] coordinates array.</p>
 <p>Any string is a valid polyline, but if you provide this
@@ -26,10 +26,12 @@ outside of the normal range.</p>
 <h4 class="tsd-parameters-title">Parameters</h4>
 <ul class="tsd-parameter-list">
 <li>
-<h5>str: <span class="tsd-signature-type">string</span></h5></li></ul></div>
+<h5>str: <span class="tsd-signature-type">string</span></h5></li>
+<li>
+<h5><code class="tsd-tag ts-flagOptional">Optional</code> precision: <span class="tsd-signature-type">number</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Position</span><span class="tsd-signature-symbol">[]</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/placemark/polyline/blob/1f60bed/lib/index.ts#L46">index.ts:46</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/placemark/polyline/blob/e5fa2f0/lib/index.ts#L44">index.ts:44</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/decode.html
+++ b/docs/functions/decode.html
@@ -28,10 +28,10 @@ outside of the normal range.</p>
 <li>
 <h5>str: <span class="tsd-signature-type">string</span></h5></li>
 <li>
-<h5><code class="tsd-tag ts-flagOptional">Optional</code> precision: <span class="tsd-signature-type">number</span></h5></li></ul></div>
+<h5>precision: <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Position</span><span class="tsd-signature-symbol">[]</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/placemark/polyline/blob/e5fa2f0/lib/index.ts#L44">index.ts:44</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/placemark/polyline/blob/a9f4f6d/lib/index.ts#L44">index.ts:44</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/encode.html
+++ b/docs/functions/encode.html
@@ -15,7 +15,7 @@
 <h1>Function encode</h1></div>
 <section class="tsd-panel">
 <ul class="tsd-signatures tsd-kind-function">
-<li class="tsd-signature tsd-anchor-link" id="encode">encode<span class="tsd-signature-symbol">(</span>coordinates<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><a href="#encode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></li>
+<li class="tsd-signature tsd-anchor-link" id="encode">encode<span class="tsd-signature-symbol">(</span>coordinates<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span>, precision<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><a href="#encode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Encodes the given [latitude, longitude] coordinates array.</p>
 
@@ -27,10 +27,14 @@
 <li>
 <h5>coordinates: <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">[]</span></h5>
 <div class="tsd-comment tsd-typography"><p>Coordinates, in longitude, latitude order</p>
+</div></li>
+<li>
+<h5><code class="tsd-tag ts-flagOptional">Optional</code> precision: <span class="tsd-signature-type">number</span></h5>
+<div class="tsd-comment tsd-typography"><p>Defaults to 5</p>
 </div></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/placemark/polyline/blob/1f60bed/lib/index.ts#L100">index.ts:100</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/placemark/polyline/blob/e5fa2f0/lib/index.ts#L103">index.ts:103</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/encode.html
+++ b/docs/functions/encode.html
@@ -29,12 +29,10 @@
 <div class="tsd-comment tsd-typography"><p>Coordinates, in longitude, latitude order</p>
 </div></li>
 <li>
-<h5><code class="tsd-tag ts-flagOptional">Optional</code> precision: <span class="tsd-signature-type">number</span></h5>
-<div class="tsd-comment tsd-typography"><p>Defaults to 5</p>
-</div></li></ul></div>
+<h5>precision: <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/placemark/polyline/blob/e5fa2f0/lib/index.ts#L103">index.ts:103</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/placemark/polyline/blob/a9f4f6d/lib/index.ts#L99">index.ts:99</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/geoJSONToPolyline.html
+++ b/docs/functions/geoJSONToPolyline.html
@@ -27,12 +27,10 @@
 <div class="tsd-comment tsd-typography"><p>A LineString</p>
 </div></li>
 <li>
-<h5><code class="tsd-tag ts-flagOptional">Optional</code> precision: <span class="tsd-signature-type">number</span></h5>
-<div class="tsd-comment tsd-typography"><p>Defaults to 5</p>
-</div></li></ul></div>
+<h5>precision: <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/placemark/polyline/blob/e5fa2f0/lib/index.ts#L132">index.ts:132</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/placemark/polyline/blob/a9f4f6d/lib/index.ts#L124">index.ts:124</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/geoJSONToPolyline.html
+++ b/docs/functions/geoJSONToPolyline.html
@@ -15,7 +15,7 @@
 <h1>Function geoJSONToPolyline</h1></div>
 <section class="tsd-panel">
 <ul class="tsd-signatures tsd-kind-function">
-<li class="tsd-signature tsd-anchor-link" id="geoJSONToPolyline">geoJSONTo<wbr/>Polyline<span class="tsd-signature-symbol">(</span>geojson<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">LineString</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><a href="#geoJSONToPolyline" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></li>
+<li class="tsd-signature tsd-anchor-link" id="geoJSONToPolyline">geoJSONTo<wbr/>Polyline<span class="tsd-signature-symbol">(</span>geojson<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">LineString</span>, precision<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><a href="#geoJSONToPolyline" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Encodes a GeoJSON LineString feature/geometry.</p>
 </div>
@@ -25,10 +25,14 @@
 <li>
 <h5>geojson: <span class="tsd-signature-type">LineString</span></h5>
 <div class="tsd-comment tsd-typography"><p>A LineString</p>
+</div></li>
+<li>
+<h5><code class="tsd-tag ts-flagOptional">Optional</code> precision: <span class="tsd-signature-type">number</span></h5>
+<div class="tsd-comment tsd-typography"><p>Defaults to 5</p>
 </div></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/placemark/polyline/blob/1f60bed/lib/index.ts#L124">index.ts:124</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/placemark/polyline/blob/e5fa2f0/lib/index.ts#L132">index.ts:132</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/polylineToGeoJSON.html
+++ b/docs/functions/polylineToGeoJSON.html
@@ -15,7 +15,7 @@
 <h1>Function polylineToGeoJSON</h1></div>
 <section class="tsd-panel">
 <ul class="tsd-signatures tsd-kind-function">
-<li class="tsd-signature tsd-anchor-link" id="polylineToGeoJSON">polyline<wbr/>To<wbr/>GeoJSON<span class="tsd-signature-symbol">(</span>str<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">LineString</span><a href="#polylineToGeoJSON" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></li>
+<li class="tsd-signature tsd-anchor-link" id="polylineToGeoJSON">polyline<wbr/>To<wbr/>GeoJSON<span class="tsd-signature-symbol">(</span>str<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, precision<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">LineString</span><a href="#polylineToGeoJSON" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Decodes to a GeoJSON LineString geometry.</p>
 </div>
@@ -25,10 +25,14 @@
 <li>
 <h5>str: <span class="tsd-signature-type">string</span></h5>
 <div class="tsd-comment tsd-typography"><p>An encoded polyline as a string.</p>
+</div></li>
+<li>
+<h5><code class="tsd-tag ts-flagOptional">Optional</code> precision: <span class="tsd-signature-type">number</span></h5>
+<div class="tsd-comment tsd-typography"><p>Defaults to 5</p>
 </div></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">LineString</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/placemark/polyline/blob/1f60bed/lib/index.ts#L133">index.ts:133</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/placemark/polyline/blob/e5fa2f0/lib/index.ts#L145">index.ts:145</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/polylineToGeoJSON.html
+++ b/docs/functions/polylineToGeoJSON.html
@@ -27,12 +27,10 @@
 <div class="tsd-comment tsd-typography"><p>An encoded polyline as a string.</p>
 </div></li>
 <li>
-<h5><code class="tsd-tag ts-flagOptional">Optional</code> precision: <span class="tsd-signature-type">number</span></h5>
-<div class="tsd-comment tsd-typography"><p>Defaults to 5</p>
-</div></li></ul></div>
+<h5>precision: <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 5</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">LineString</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/placemark/polyline/blob/e5fa2f0/lib/index.ts#L145">index.ts:145</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/placemark/polyline/blob/a9f4f6d/lib/index.ts#L133">index.ts:133</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,9 +11,12 @@
 <div class="tsd-page-title">
 <h2>@placemarkio/polyline</h2></div>
 <div class="tsd-panel tsd-typography">
-<a href="#polyline" id="polyline" style="color: inherit; text-decoration: none;">
-  <h1>polyline</h1>
+<a href="#placemarkiopolyline" id="placemarkiopolyline" style="color: inherit; text-decoration: none;">
+  <h1>@placemarkio/polyline</h1>
 </a>
+<p><a href="https://badge.fury.io/js/@placemarkio%2Fpolyline"><img src="https://badge.fury.io/js/@placemarkio%2Fpolyline.svg" alt="npm version"></a></p>
+<pre><code><span class="hl-0">@</span><span class="hl-1">placemarkio</span><span class="hl-0">/</span><span class="hl-1">polyline</span>
+</code></pre>
 <p><em>polyline development is supported by 🌎 <a href="https://placemark.io/">placemark.io</a></em></p>
 <p>A maintained fork of the <a href="https://github.com/mapbox/polyline">Mapbox module</a>.</p>
 <p>Differences:</p>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,5 @@
 import type { LineString, Position } from "geojson";
 
-const factor = 100000; // Math.pow(10, 5);
-
 // https://github.com/mapbox/polyline/blob/master/src/polyline.js
 
 // Based off of [the offical Google document](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
@@ -43,7 +41,11 @@ function resultChange(result: number) {
  * with an arbitrary string, it'll produce coordinates well
  * outside of the normal range.
  */
-export function decode(str: string): Position[] {
+export function decode(str: string, precision?: number): Position[] {
+  if (typeof(precision) === 'undefined') {
+    precision = 5;
+  }
+  const factor = Math.pow(10, precision);
   let index = 0;
   let lat = 0;
   let lng = 0;
@@ -95,12 +97,17 @@ export function decode(str: string): Position[] {
  * Encodes the given [latitude, longitude] coordinates array.
  *
  * @param coordinates Coordinates, in longitude, latitude order
+ * @param precision Defaults to 5
  * @returns encoded polyline
  */
-export function encode(coordinates: number[][]) {
+export function encode(coordinates: number[][], precision?: number) {
   if (!coordinates.length) {
     return "";
   }
+  if (typeof(precision) === 'undefined') {
+    precision = 5;
+  }
+  const factor = Math.pow(10, precision);
 
   let output =
     encodeNumber(coordinates[0][1], 0, factor) +
@@ -120,18 +127,26 @@ export function encode(coordinates: number[][]) {
  * Encodes a GeoJSON LineString feature/geometry.
  *
  * @param geojson A LineString
+ * @param precision Defaults to 5
  */
-export function geoJSONToPolyline(geojson: LineString) {
-  return encode(geojson.coordinates);
+export function geoJSONToPolyline(geojson: LineString, precision?: number) {
+  if (typeof(precision) === 'undefined') {
+    precision = 5;
+  }
+  return encode(geojson.coordinates, precision);
 }
 
 /**
  * Decodes to a GeoJSON LineString geometry.
  *
  * @param str An encoded polyline as a string.
+ * @param precision Defaults to 5
  */
-export function polylineToGeoJSON(str: string): LineString {
-  const coords = decode(str);
+export function polylineToGeoJSON(str: string, precision?: number): LineString {
+  if (typeof(precision) === 'undefined') {
+    precision = 5;
+  }
+  const coords = decode(str, precision);
   return {
     type: "LineString",
     coordinates: coords,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,10 +41,7 @@ function resultChange(result: number) {
  * with an arbitrary string, it'll produce coordinates well
  * outside of the normal range.
  */
-export function decode(str: string, precision?: number): Position[] {
-  if (typeof(precision) === 'undefined') {
-    precision = 5;
-  }
+export function decode(str: string, precision: number = 5): Position[] {
   const factor = Math.pow(10, precision);
   let index = 0;
   let lat = 0;
@@ -97,15 +94,11 @@ export function decode(str: string, precision?: number): Position[] {
  * Encodes the given [latitude, longitude] coordinates array.
  *
  * @param coordinates Coordinates, in longitude, latitude order
- * @param precision Defaults to 5
  * @returns encoded polyline
  */
-export function encode(coordinates: number[][], precision?: number) {
+export function encode(coordinates: number[][], precision: number = 5) {
   if (!coordinates.length) {
     return "";
-  }
-  if (typeof(precision) === 'undefined') {
-    precision = 5;
   }
   const factor = Math.pow(10, precision);
 
@@ -127,12 +120,8 @@ export function encode(coordinates: number[][], precision?: number) {
  * Encodes a GeoJSON LineString feature/geometry.
  *
  * @param geojson A LineString
- * @param precision Defaults to 5
  */
-export function geoJSONToPolyline(geojson: LineString, precision?: number) {
-  if (typeof(precision) === 'undefined') {
-    precision = 5;
-  }
+export function geoJSONToPolyline(geojson: LineString, precision: number = 5) {
   return encode(geojson.coordinates, precision);
 }
 
@@ -140,12 +129,8 @@ export function geoJSONToPolyline(geojson: LineString, precision?: number) {
  * Decodes to a GeoJSON LineString geometry.
  *
  * @param str An encoded polyline as a string.
- * @param precision Defaults to 5
  */
-export function polylineToGeoJSON(str: string, precision?: number): LineString {
-  if (typeof(precision) === 'undefined') {
-    precision = 5;
-  }
+export function polylineToGeoJSON(str: string, precision: number = 5): LineString {
   const coords = decode(str, precision);
   return {
     type: "LineString",


### PR DESCRIPTION
Why:
* Some services use a precision value of 5 and others use 6

How:
* Add an optional precision parameter to exported functions
* Set that to 5 if no value is provided
* Calculate the factor based on the optional precision value
* Update documentation with `yarn doc`

Links:
* https://docs.stadiamaps.com/static-maps/#line-components
* https://docs.stadiamaps.com/routing/
  * The precision is 6 for their `shape` response (undocumented)