### PR TITLE
move @biomejs/biome into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
 	"author": "Tom MacWright",
 	"license": "MIT",
 	"dependencies": {
-		"@biomejs/biome": "^2.3.5",
 		"@types/geojson": "*"
 	},
 	"devDependencies": {
+		"@biomejs/biome": "^2.3.5",
 		"@changesets/cli": "^2.29.7",
 		"husky": "^8.0.1",
 		"prettier": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,13 @@ importers:
 
   .:
     dependencies:
-      '@biomejs/biome':
-        specifier: ^2.3.5
-        version: 2.3.5
       '@types/geojson':
         specifier: '*'
         version: 7946.0.16
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.3.5
+        version: 2.3.5
       '@changesets/cli':
         specifier: ^2.29.7
         version: 2.29.7(@types/node@24.10.1)


### PR DESCRIPTION
My rationale is that my Rails project which uses polyline doesn't need to also bring in its linting/formatting dependency.

I made the changes by moving the `"@biomejs/biome": "^2.3.5",` line down into the `devDependencies` section and then running `pnpm i`. I ran `pnpm test` afterwards, and they all still passed.

I'm a bit out of my depth, so apologies if any of this is useless noise.